### PR TITLE
use https transport during installation process

### DIFF
--- a/distribute_setup.py
+++ b/distribute_setup.py
@@ -47,7 +47,7 @@ except ImportError:
         return os.spawnl(os.P_WAIT, sys.executable, *args) == 0
 
 DEFAULT_VERSION = "0.6.24"
-DEFAULT_URL = "http://pypi.python.org/packages/source/d/distribute/"
+DEFAULT_URL = "https://pypi.python.org/packages/source/d/distribute/"
 SETUPTOOLS_FAKED_VERSION = "0.6c11"
 
 SETUPTOOLS_PKG_INFO = """\


### PR DESCRIPTION
Official pip index is now closed by http: https://mail.python.org/pipermail/distutils-sig/2017-October/031712.html
Here is patch to use https instead of http.
